### PR TITLE
Add support for custom components 'as' props

### DIFF
--- a/.changeset/shaggy-glasses-argue.md
+++ b/.changeset/shaggy-glasses-argue.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/react-test-nextjs": minor
+"@quiltt/react": minor
+"@quiltt/core": minor
+---
+
+Add support for custom components 'as' props

--- a/ECMAScript/react/src/components/QuilttButton.tsx
+++ b/ECMAScript/react/src/components/QuilttButton.tsx
@@ -1,28 +1,24 @@
-import { FC, DetailedHTMLProps, ButtonHTMLAttributes } from 'react'
+import { PropsWithChildren } from 'react'
 import { useQuilttConnector } from '..'
+import { AnyTag, PropsOf } from '../types'
 
-type QuilttButtonProps = DetailedHTMLProps<
-  ButtonHTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> & {
+type QuilttButtonProps<T extends AnyTag> = {
+  as?: T
   connectorId: string
   connectionId?: string // For Reconnect Mode
-}
+} & PropsWithChildren
 
-export const QuilttButton: FC<QuilttButtonProps> = ({
+export const QuilttButton = <T extends AnyTag = 'button'>({
+  as,
   connectorId,
   connectionId,
-  children,
   ...props
-}) => {
+}: QuilttButtonProps<T> & PropsOf<T>) => {
   useQuilttConnector()
 
-  return (
-    // eslint-disable-next-line react/no-unknown-property
-    <button quiltt-button={connectorId} quiltt-connection={connectionId} {...props}>
-      {children}
-    </button>
-  )
+  const Button = as || 'button'
+
+  return <Button quiltt-button={connectorId} quiltt-connection={connectionId} {...props}></Button>
 }
 
 export default QuilttButton

--- a/ECMAScript/react/src/components/QuilttContainer.tsx
+++ b/ECMAScript/react/src/components/QuilttContainer.tsx
@@ -1,24 +1,29 @@
-import { FC, DetailedHTMLProps, HTMLAttributes } from 'react'
+import { PropsWithChildren } from 'react'
 import { useQuilttConnector } from '..'
+import { AnyTag, PropsOf } from '../types'
 
-type QuilttContainerProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
+type QuilttContainerProps<T extends AnyTag> = {
+  as?: T
   connectorId: string
   connectionId?: string // For Reconnect Mode
-}
+} & PropsWithChildren
 
-export const QuilttContainer: FC<QuilttContainerProps> = ({
+export const QuilttContainer = <T extends AnyTag = 'div'>({
+  as,
   connectorId,
   connectionId,
-  children,
   ...props
-}) => {
+}: QuilttContainerProps<T> & PropsOf<T>) => {
   useQuilttConnector()
 
+  const Container = as || 'div'
+
   return (
-    // eslint-disable-next-line react/no-unknown-property
-    <div quiltt-container={connectorId} quiltt-connection={connectionId} {...props}>
-      {children}
-    </div>
+    <Container
+      quiltt-container={connectorId}
+      quiltt-connection={connectionId}
+      {...props}
+    ></Container>
   )
 }
 

--- a/ECMAScript/react/src/types.ts
+++ b/ECMAScript/react/src/types.ts
@@ -1,0 +1,9 @@
+import { Component, ComponentType, FC } from 'react'
+
+export type AnyTag = string | FC<any> | (new (props: any) => Component)
+
+export type PropsOf<Tag> = Tag extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[Tag]
+  : Tag extends ComponentType<infer Props>
+  ? Props & JSX.IntrinsicAttributes
+  : never

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestCustomButton.cy.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestCustomButton.cy.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
-import TestCustomLauncher from './TestCustomLauncher'
+import TestCustomButton from './TestCustomButton'
 
-describe('<TestCustomLauncher />', () => {
+describe('<TestCustomButton />', () => {
   it('renders', () => {
-    cy.mount(<TestCustomLauncher />)
+    cy.mount(<TestCustomButton />)
 
-    cy.get('a').should('contains.text', 'Launch with HTML')
+    cy.get('button[quiltt-button="connector"]').should('have.text', 'Launch with Custom Component')
 
     // Wait for script to become interactive. This is almost instananeous locally but takes time in CI.
     cy.wait(1250)
 
     // Launch the Connector
     cy.get('iframe#quiltt--frame').should('not.exist')
-    cy.get('a').click()
+    cy.get('button[quiltt-button="connector"]').click()
     cy.get('iframe#quiltt--frame').should('be.visible')
 
     // @todo: Check that iframe is rendered. https://github.com/cypress-io/cypress/issues/136

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestCustomButton.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestCustomButton.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { FC, PropsWithChildren, ReactNode } from 'react'
+import { QuilttButton } from '@quiltt/react'
+
+const CustomButton = ({ children, ...props }: any) => {
+  return <button className="bg-purple-500 hover:bg-purple-900 text-white py-2 px-4 rounded-md" {...props}>
+    {children}
+  </button>
+}
+
+export const TestCustomButton = () => {
+  return (
+    <QuilttButton as={CustomButton} connectorId="connector">
+      Launch with Custom Component
+    </QuilttButton>
+  )
+}
+export default TestCustomButton

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestCustomContainer.cy.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestCustomContainer.cy.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { TestCustomContainer } from './TestCustomContainer'
+
+describe('<TestCustomContainer />', () => {
+  it('renders', () => {
+    // see: https://on.cypress.io/mounting-react
+    cy.mount(<TestCustomContainer />)
+
+    // Find the iframe in the container
+    cy.get('div[quiltt-container="connector"]').within(() => {
+      cy.get('iframe#quiltt--frame').should('be.visible')
+    })
+  })
+})

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestCustomContainer.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestCustomContainer.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { QuilttContainer } from '@quiltt/react'
+import { FC } from 'react'
+
+const CustomContainer: FC = ({ ...props }) => {
+  return <div className="border-4 border-purple-500 hover:border-blue-500 h-full"
+    {...props}>
+  </div>
+}
+
+
+export const TestCustomContainer = () => {
+  return (
+    <QuilttContainer as={CustomContainer} connectorId="connector"/>
+  )
+}
+
+export default TestCustomContainer

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestHTMLLauncher.cy.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestHTMLLauncher.cy.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import TestHTMLLauncher from './TestHTMLLauncher'
+
+describe('<TestHTMLLauncher />', () => {
+  it('renders', () => {
+    cy.mount(<TestHTMLLauncher />)
+
+    cy.get('a').should('contains.text', 'Launch with HTML')
+
+    // Wait for script to become interactive. This is almost instananeous locally but takes time in CI.
+    cy.wait(1250)
+
+    // Launch the Connector
+    cy.get('iframe#quiltt--frame').should('not.exist')
+    cy.get('a').click()
+    cy.get('iframe#quiltt--frame').should('be.visible')
+
+    // @todo: Check that iframe is rendered. https://github.com/cypress-io/cypress/issues/136
+    // cy.get('iframe#quiltt--frame').should('contains.text', 'Stitching finance together')
+  })
+})

--- a/ECMAScript/react/test-apps/nextjs/app/components/TestHTMLLauncher.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/components/TestHTMLLauncher.tsx
@@ -2,7 +2,7 @@
 
 import { useQuilttConnector } from '@quiltt/react'
 
-export const TestCustomLauncher = () => {
+export const TestHTMLLauncher = () => {
   // Load the script
   useQuilttConnector()
 
@@ -16,4 +16,4 @@ export const TestCustomLauncher = () => {
     </a>
   )
 }
-export default TestCustomLauncher
+export default TestHTMLLauncher

--- a/ECMAScript/react/test-apps/nextjs/app/components/index.ts
+++ b/ECMAScript/react/test-apps/nextjs/app/components/index.ts
@@ -1,3 +1,5 @@
-export * from './TestCustomLauncher'
+export * from './TestCustomButton'
+export * from './TestCustomContainer'
+export * from './TestHTMLLauncher'
 export * from './TestQuilttButton'
 export * from './TestQuilttContainer'

--- a/ECMAScript/react/test-apps/nextjs/app/page.tsx
+++ b/ECMAScript/react/test-apps/nextjs/app/page.tsx
@@ -1,18 +1,20 @@
 'use client'
 
-import { TestCustomLauncher, TestQuilttButton, TestQuilttContainer } from './components'
+import { TestCustomButton, TestCustomContainer, TestHTMLLauncher, TestQuilttButton, TestQuilttContainer } from './components'
 
 export default function Home() {
   return (
     <main className="flex h-screen justify-center items-center space-x-48">
       <div className="flex flex-col space-y-5">
         <h1 className="text-2xl text-center py-6">Modal launchers</h1>
-        <TestCustomLauncher />
+        <TestHTMLLauncher />
         <TestQuilttButton />
+        <TestCustomButton />
       </div>
       <div className="flex flex-col h-3/4 w-1/5">
         <h1 className="text-2xl text-center py-6">Container</h1>
         <TestQuilttContainer />
+        <TestCustomContainer />
       </div>
     </main>
   )


### PR DESCRIPTION
It's easy to have working code, it's much harder to appease the typescript gods