### PR TITLE
Implement DisconnectButton

### DIFF
--- a/ECMAScript/core/src/api/graphql/client.ts
+++ b/ECMAScript/core/src/api/graphql/client.ts
@@ -1,5 +1,5 @@
-import type { ApolloClientOptions, Operation } from '@apollo/client/index.js'
-import { ApolloClient, ApolloLink } from '@apollo/client/index.js'
+import type { ApolloClientOptions, Operation } from '@apollo/client'
+import { ApolloClient, ApolloLink } from '@apollo/client'
 
 import { debugging } from '../../configuration'
 import {
@@ -44,5 +44,5 @@ export class QuilttClient<T> extends ApolloClient<T> {
   }
 }
 
-export { InMemoryCache, gql, useMutation, useQuery, useSubscription } from '@apollo/client/index.js'
-export type { NormalizedCacheObject, OperationVariables } from '@apollo/client/index.js'
+export { InMemoryCache, gql, useMutation, useQuery, useSubscription } from '@apollo/client'
+export type { NormalizedCacheObject, OperationVariables } from '@apollo/client'

--- a/ECMAScript/core/src/api/graphql/links/ActionCableLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/ActionCableLink.ts
@@ -1,6 +1,6 @@
 import { GlobalStorage } from '@/Storage'
-import type { FetchResult, NextLink, Operation } from '@apollo/client/core/index.js'
-import { ApolloLink, Observable } from '@apollo/client/core/index.js'
+import type { FetchResult, NextLink, Operation } from '@apollo/client'
+import { ApolloLink, Observable } from '@apollo/client'
 import { print } from 'graphql'
 import { endpointWebsockets } from '../../../configuration'
 import type { Consumer } from './actioncable'

--- a/ECMAScript/core/src/api/graphql/links/AuthLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/AuthLink.ts
@@ -1,5 +1,5 @@
-import type { FetchResult, NextLink, Observable, Operation } from '@apollo/client/index.js'
-import { ApolloLink } from '@apollo/client/index.js'
+import type { FetchResult, NextLink, Observable, Operation } from '@apollo/client'
+import { ApolloLink } from '@apollo/client'
 
 import { GlobalStorage } from '@/Storage'
 

--- a/ECMAScript/core/src/api/graphql/links/BatchHttpLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/BatchHttpLink.ts
@@ -1,4 +1,4 @@
-import { BatchHttpLink as ApolloHttpLink } from '@apollo/client/link/batch-http/index.js'
+import { BatchHttpLink as ApolloHttpLink } from '@apollo/client/link/batch-http'
 
 import fetch from 'cross-fetch'
 

--- a/ECMAScript/core/src/api/graphql/links/ErrorLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/ErrorLink.ts
@@ -1,7 +1,7 @@
 import { GlobalStorage } from '@/Storage'
 
-import type { ServerError } from '@apollo/client/index.js'
-import { onError } from '@apollo/client/link/error/index.js'
+import type { ServerError } from '@apollo/client'
+import { onError } from '@apollo/client/link/error'
 
 export const ErrorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors) {

--- a/ECMAScript/core/src/api/graphql/links/ForwardableLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/ForwardableLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client'
 
 export const ForwardableLink = new ApolloLink((operation, forward) => forward(operation))
 

--- a/ECMAScript/core/src/api/graphql/links/HttpLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/HttpLink.ts
@@ -1,4 +1,4 @@
-import { HttpLink as ApolloHttpLink } from '@apollo/client/link/http/index.js'
+import { HttpLink as ApolloHttpLink } from '@apollo/client/link/http'
 
 import fetch from 'cross-fetch'
 

--- a/ECMAScript/core/src/api/graphql/links/RetryLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/RetryLink.ts
@@ -1,5 +1,5 @@
-import type { ServerError } from '@apollo/client/index.js'
-import { RetryLink as ApolloRetryLink } from '@apollo/client/link/retry/index.js'
+import type { ServerError } from '@apollo/client'
+import { RetryLink as ApolloRetryLink } from '@apollo/client/link/retry'
 
 export const RetryLink = new ApolloRetryLink({
   attempts: {

--- a/ECMAScript/core/src/api/graphql/links/TerminatingLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/TerminatingLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client'
 
 export const TerminatingLink = new ApolloLink(() => null)
 

--- a/ECMAScript/core/src/api/graphql/links/VersionLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/VersionLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client'
 
 import { version } from '../../../configuration'
 

--- a/ECMAScript/react/package.json
+++ b/ECMAScript/react/package.json
@@ -45,14 +45,14 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@quiltt/core": "workspace:*"
+    "@quiltt/core": "workspace:*",
+    "@apollo/client": "^3.7.16"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@apollo/client": "3.7.16",
     "@trivago/prettier-plugin-sort-imports": "4.1.1",
     "@types/node": "18.16.18",
     "@types/react": "18.2.7",

--- a/ECMAScript/react/src/hooks/connection/index.ts
+++ b/ECMAScript/react/src/hooks/connection/index.ts
@@ -1,0 +1,1 @@
+export * from './useDisconnectConnection'

--- a/ECMAScript/react/src/hooks/connection/useDisconnectConnection.ts
+++ b/ECMAScript/react/src/hooks/connection/useDisconnectConnection.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import { gql, useMutation } from '@quiltt/core'
+
+const CONNECTION_DISCONNECT = gql`
+  mutation ConnectionDelete($id: ID!) {
+    connectionDelete(input: { id: $id }) {
+      success
+    }
+  }
+`
+
+/**
+ * Disconnect a connection by ID
+ */
+export const useDisconnectConnection = (connectionId: string) => {
+  const [executeMutation] = useMutation(CONNECTION_DISCONNECT, {
+    variables: { id: connectionId },
+  })
+
+  /**
+  /* @example: const success = disconnect()
+   * @return {boolean}.
+   */
+  const disconnect = useCallback(async (): Promise<boolean> => {
+    const { data } = await executeMutation()
+
+    return data?.connectionDelete?.success || false
+  }, [executeMutation])
+
+  return disconnect
+}
+
+export default useDisconnectConnection

--- a/ECMAScript/react/src/hooks/index.ts
+++ b/ECMAScript/react/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './helpers'
 export * from './session'
+export * from './useConnection'
 export * from './useQuilttClient'
 export * from './useQuilttConnector'
 export * from './useQuilttSession'

--- a/ECMAScript/react/src/hooks/useConnection.ts
+++ b/ECMAScript/react/src/hooks/useConnection.ts
@@ -1,0 +1,11 @@
+import { useDisconnectConnection } from './connection'
+
+export const useConnection = (connectionId: string) => {
+  const disconnect = useDisconnectConnection(connectionId)
+
+  return {
+    disconnect,
+  }
+}
+
+export default useConnection

--- a/ECMAScript/react/src/hooks/useQuilttClient.ts
+++ b/ECMAScript/react/src/hooks/useQuilttClient.ts
@@ -1,4 +1,4 @@
-import { useApolloClient } from '@apollo/client/index.js'
+import { useApolloClient } from '@apollo/client'
 
 export const useQuilttClient = useApolloClient
 

--- a/ECMAScript/react/test-apps/nextjs/next.config.js
+++ b/ECMAScript/react/test-apps/nextjs/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {}
 
-module.exports = nextConfig;
+module.exports = nextConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,13 +75,13 @@ importers:
 
   ECMAScript/react:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.7.16
+        version: 3.7.16(graphql@16.7.1)(react-dom@18.2.0)(react@18.2.0)
       '@quiltt/core':
         specifier: workspace:*
         version: link:../core
     devDependencies:
-      '@apollo/client':
-        specifier: 3.7.16
-        version: 3.7.16(graphql@16.7.1)(react-dom@18.2.0)(react@18.2.0)
       '@trivago/prettier-plugin-sort-imports':
         specifier: 4.1.1
         version: 4.1.1(prettier@2.8.8)
@@ -229,6 +229,7 @@ packages:
       ts-invariant: 0.10.3
       tslib: 2.5.0
       zen-observable-ts: 1.2.5
+    dev: false
 
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
@@ -848,6 +849,7 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.7.1
+    dev: false
 
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
@@ -1341,24 +1343,28 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
+    dev: false
 
   /@wry/equality@0.5.3:
     resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
+    dev: false
 
   /@wry/trie@0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
+    dev: false
 
   /@wry/trie@0.4.3:
     resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.9.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3255,10 +3261,12 @@ packages:
     dependencies:
       graphql: 16.7.1
       tslib: 2.5.0
+    dev: false
 
   /graphql@16.7.1:
     resolution: {integrity: sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -3313,6 +3321,7 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
+    dev: false
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -4224,6 +4233,7 @@ packages:
     dependencies:
       '@wry/context': 0.7.0
       '@wry/trie': 0.3.2
+    dev: false
 
   /optionator@0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
@@ -4713,6 +4723,7 @@ packages:
   /response-iterator@0.2.6:
     resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
     engines: {node: '>=0.8'}
+    dev: false
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -5109,6 +5120,7 @@ packages:
   /symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+    dev: false
 
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
@@ -5253,6 +5265,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
+    dev: false
 
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
@@ -5736,9 +5749,11 @@ packages:
     resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
     dependencies:
       zen-observable: 0.8.15
+    dev: false
 
   /zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+    dev: false
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}


### PR DESCRIPTION
## Proposed Changes
- Update @apollo/client imports to fix typescript issues
- Move @apollo/client into @quiltt/react's `dependencies` as we are importing directly from it. Version is set to match the package in @quiltt/core
- Implement a `useDisconnectConnection` and `useConnection` composite hook.

This allows you to do: 

```tsx
const { disconnect } = useConnection("my-connection-id")

return(
  <button onClick={() => disconnect()}>
    Disconnect
  </button>
)
```

## Todos: 
- [ ] extract querying logic into a Component, mirroring interface of other buttons
- [ ] remove useConnection hook
- [ ] Smoke test