### PR TITLE
Add retries to auth api when dealing with network related errors

### DIFF
--- a/.changeset/afraid-cobras-chew.md
+++ b/.changeset/afraid-cobras-chew.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/react": patch
+"@quiltt/core": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+Add retries to auth api when dealing with network related errors

--- a/ECMAScript/core/src/api/rest/AuthAPI.ts
+++ b/ECMAScript/core/src/api/rest/AuthAPI.ts
@@ -1,5 +1,5 @@
-import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import axios from 'axios'
+import type { AxiosRequestConfig, AxiosResponse } from './axios'
+import { axios } from './axios'
 
 import { endpointAuth } from '../../configuration'
 
@@ -93,6 +93,7 @@ export class AuthAPI {
     return {
       headers: headers,
       validateStatus: this.validateStatus,
+      retry: true,
     }
   }
 

--- a/ECMAScript/core/src/api/rest/axios.ts
+++ b/ECMAScript/core/src/api/rest/axios.ts
@@ -1,0 +1,52 @@
+import type { AxiosRequestConfig as RequestConfig } from 'axios'
+import Axios from 'axios'
+
+export type { AxiosResponse } from 'axios'
+export type AxiosRequestConfig<D = any> = RequestConfig<D> & {
+  retry: boolean
+}
+
+const RETRY_DELAY = 150 // ms
+const RETRIES = 3 // 150, 300, 450 = 900 ms
+
+// Create an axios singleton for Quiltt, to prevent mutating other instances
+const axios = Axios.create()
+
+// Example: axios.get(url, { retry: true })
+axios.interceptors.response.use(undefined, (error) => {
+  const { config, message, response } = error
+  const messageLower = message.toLowerCase()
+
+  if (!config || !config.retry) {
+    return Promise.reject(error)
+  }
+
+  // Retry Network timeout, Network errors, and Too Many Requests
+  if (
+    !(
+      messageLower.includes('timeout') ||
+      messageLower.includes('network error') ||
+      response?.status === 429
+    )
+  ) {
+    return Promise.reject(error)
+  }
+
+  if (config.retriesRemaining === undefined) {
+    config.retriesRemaining = RETRIES - 1
+  } else if (config.retriesRemaining === 1) {
+    return Promise.reject(error)
+  } else {
+    config.retriesRemaining -= 1
+  }
+
+  const delay = new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), RETRY_DELAY)
+  })
+
+  return delay.then(() => axios(config))
+})
+
+export { axios }
+
+export default axios

--- a/ECMAScript/react/src/hooks/session/useIdentifySession.ts
+++ b/ECMAScript/react/src/hooks/session/useIdentifySession.ts
@@ -29,16 +29,16 @@ export const useIdentifySession: UseIdentifySession = (auth, setSession) => {
       const unprocessableResponse = response as UnprocessableResponse
 
       switch (response.status) {
-        case 201:
+        case 201: // Created
           setSession((response as SessionResponse).data.token)
           if (callbacks.onSuccess) return callbacks.onSuccess()
           break
 
-        case 202:
+        case 202: // Accepted
           if (callbacks.onChallenged) return callbacks.onChallenged()
           break
 
-        case 422:
+        case 422: // Unprocessable Content
           if (callbacks.onError) return callbacks.onError(unprocessableResponse.data)
           break
 


### PR DESCRIPTION
I've tested the interceptor using codesandbox.io