### PR TITLE
Add 'noUncheckedIndexedAccess' to tsconfig.base.json

### DIFF
--- a/.changeset/famous-nails-reply.md
+++ b/.changeset/famous-nails-reply.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+Add noUncheckedIndexedAccess to tsconfig.base.json

--- a/ECMAScript/core/src/JsonWebToken.ts
+++ b/ECMAScript/core/src/JsonWebToken.ts
@@ -42,7 +42,7 @@ export const JsonWebTokenParse = <T>(
   const [_header, payload, _signature] = token.split('.')
 
   try {
-    return { token: token, claims: JSON.parse(atob(payload)) }
+    return { token: token, claims: JSON.parse(atob(payload!)) }
   } catch (error) {
     console.error(`Invalid Session Token: ${error}`)
   }

--- a/ECMAScript/core/src/Storage/Local.ts
+++ b/ECMAScript/core/src/Storage/Local.ts
@@ -65,11 +65,13 @@ export class LocalStorage<T> {
   subscribe = (key: string, observer: Observer<T>) => {
     if (!this.observers[key]) this.observers[key] = []
 
-    this.observers[key].push(observer)
+    this.observers[key]?.push(observer)
   }
 
   unsubscribe = (key: string, observer: Observer<T>) => {
-    this.observers[key] = this.observers[key]?.filter((update) => update !== observer)
+    this.observers[key] = this.observers[key]?.filter(
+      (update) => update !== observer
+    ) as Observer<T>[]
   }
 
   // if there is a key, then trigger the related updates. If there is not key
@@ -79,7 +81,7 @@ export class LocalStorage<T> {
       const newState = event.newValue ? JSON.parse(event.newValue) : null
 
       if (this.observers[event.key]) {
-        this.observers[event.key].forEach((update) => update(newState))
+        this.observers[event.key]?.forEach((update) => update(newState))
       }
     } else {
       Object.entries(this.observers).forEach(([key, observers]) => {

--- a/ECMAScript/core/src/Storage/Memory.ts
+++ b/ECMAScript/core/src/Storage/Memory.ts
@@ -13,7 +13,7 @@ export class MemoryStorage<T> {
 
   get = (key: string) => {
     if (this.observables[key]) {
-      return this.observables[key].get()
+      return this.observables[key]?.get()
     } else {
       return undefined
     }
@@ -23,19 +23,19 @@ export class MemoryStorage<T> {
     if (!this.observables[key]) {
       this.observables[key] = new Observable<T>(state)
     } else {
-      this.observables[key].set(state)
+      this.observables[key]?.set(state)
     }
   }
 
   subscribe = (key: string, observer: Observer<T>): void => {
     if (!this.observables[key]) this.observables[key] = new Observable<T>()
 
-    this.observables[key].subscribe(observer)
+    this.observables[key]?.subscribe(observer)
   }
 
   unsubscribe = (key: string, observer: Observer<T>): void => {
     if (this.observables[key]) {
-      this.observables[key].unsubscribe(observer)
+      this.observables[key]?.unsubscribe(observer)
     }
   }
 }

--- a/ECMAScript/core/src/Storage/index.ts
+++ b/ECMAScript/core/src/Storage/index.ts
@@ -52,11 +52,13 @@ export class Storage<T> {
   subscribe = (key: string, observer: Observer<T>) => {
     if (!this.observers[key]) this.observers[key] = []
 
-    this.observers[key].push(observer)
+    this.observers[key]?.push(observer)
   }
 
   unsubscribe = (key: string, observer: Observer<T>) => {
-    this.observers[key] = this.observers[key]?.filter((update) => update !== observer)
+    this.observers[key] = this.observers[key]?.filter(
+      (update) => update !== observer
+    ) as Observer<T>[]
   }
 
   /**

--- a/ECMAScript/core/src/Timeoutable.ts
+++ b/ECMAScript/core/src/Timeoutable.ts
@@ -25,7 +25,9 @@ export class Timeoutable {
   private broadcast = () => {
     if (this.observers.length === 0) return
 
-    this.observers[0](undefined)
+    if (this.observers[0]) {
+      this.observers[0](undefined)
+    }
   }
 }
 

--- a/ECMAScript/core/src/api/graphql/links/ActionCableLink.ts
+++ b/ECMAScript/core/src/api/graphql/links/ActionCableLink.ts
@@ -3,7 +3,7 @@ import type { FetchResult, NextLink, Operation } from '@apollo/client/core/index
 import { ApolloLink, Observable } from '@apollo/client/core/index.js'
 import { print } from 'graphql'
 import { endpointWebsockets } from '../../../configuration'
-import type { Consumer } from './actioncable'
+import type { Consumer, Subscription } from './actioncable'
 import { createConsumer } from './actioncable'
 
 type RequestResult = FetchResult<
@@ -53,7 +53,7 @@ class ActionCableLink extends ApolloLink {
           ? this.connectionParams(operation)
           : this.connectionParams
 
-      const channel = this.cables[token].subscriptions.create(
+      const channel = this.cables[token]?.subscriptions.create(
         Object.assign(
           {},
           {
@@ -74,7 +74,7 @@ class ActionCableLink extends ApolloLink {
           },
 
           received: (payload: { result: RequestResult; more: any }) => {
-            if (payload?.result?.data || payload?.result?.errors) {
+            if (payload && ('data' in payload.result || 'errors' in payload.result)) {
               observer.next(payload.result)
             }
 
@@ -83,7 +83,7 @@ class ActionCableLink extends ApolloLink {
             }
           },
         }
-      )
+      ) as Subscription
       // Make the ActionCable subscription behave like an Apollo subscription
       return Object.assign(channel, { closed: false })
     })

--- a/ECMAScript/tsconfig.base.json
+++ b/ECMAScript/tsconfig.base.json
@@ -8,6 +8,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
This PR introduces an improvement in type safety within the codebase by adding the `noUncheckedIndexedAccess` flag to `tsconfig.base.json`. This leads to stricter type-checking of indexed access expressions that result in the type `undefined` if the index could potentially be out-of-bounds.

## Why

- Type Safety: This makes sure we catch potential undefined or null issues at compile-time rather than runtime.
- Readability: Makes it clearer that some values could be undefined and need handling.
- Maintainability: Less likely to introduce bugs in the future as the codebase grows.