### PR TITLE
SDK Events - Add "Load" EventType

### DIFF
--- a/.changeset/ten-dryers-ring.md
+++ b/.changeset/ten-dryers-ring.md
@@ -1,0 +1,6 @@
+---
+"@quiltt/core": minor
+"@quiltt/react": minor
+---
+
+Add 'Load' to ConnectorSDKEventType

--- a/ECMAScript/core/src/api/browser.ts
+++ b/ECMAScript/core/src/api/browser.ts
@@ -48,6 +48,7 @@ export type ConnectorSDKOnExitAbortCallback = (metadata: ConnectorSDKCallbackMet
 export type ConnectorSDKOnExitErrorCallback = (metadata: ConnectorSDKCallbackMetadata) => void
 
 export enum ConnectorSDKEventType {
+  Load = 'loaded',
   ExitSuccess = 'exited.successful',
   ExitAbort = 'exited.aborted',
   ExitError = 'exited.errored',


### PR DESCRIPTION
The `load` event is intended to mirror the behavior of `window.load`, and is different than any `ready` event we may or may not introduce in the future.

> The load event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts, iframes, and images. This is in contrast to [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event), which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.