### PR TITLE
Strict check on browser side code

### DIFF
--- a/.changeset/brown-onions-carry.md
+++ b/.changeset/brown-onions-carry.md
@@ -1,0 +1,5 @@
+---
+"@quiltt/core": patch
+---
+
+Skip browser code when in expo app

--- a/.changeset/small-shoes-live.md
+++ b/.changeset/small-shoes-live.md
@@ -1,5 +1,7 @@
 ---
 "@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
 ---
 
 Skip browser code when in expo app

--- a/ECMAScript/core/src/Storage/Local.ts
+++ b/ECMAScript/core/src/Storage/Local.ts
@@ -11,7 +11,7 @@ export class LocalStorage<T> {
   private observers: { [key: string]: Observer<T>[] } = {}
 
   constructor() {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && !window?.expo) {
       window.addEventListener('storage', this.handleStorageEvent.bind(this))
     }
   }

--- a/ECMAScript/core/src/Storage/Local.ts
+++ b/ECMAScript/core/src/Storage/Local.ts
@@ -29,7 +29,7 @@ export class LocalStorage<T> {
   isDisabled = (): boolean => !this.isEnabled()
 
   get = (key: string): Maybe<T> | undefined => {
-    if (typeof window === 'undefined') return undefined
+    if (typeof window === 'undefined' || !!window.expo) return undefined
 
     try {
       const state = window.localStorage.getItem(`quiltt.${key}`)
@@ -41,7 +41,7 @@ export class LocalStorage<T> {
   }
 
   set = (key: string, state: Maybe<T> | undefined): void => {
-    if (typeof window === 'undefined') return
+    if (typeof window === 'undefined' || !!window.expo) return
 
     try {
       if (state) {

--- a/ECMAScript/core/src/types.ts
+++ b/ECMAScript/core/src/types.ts
@@ -8,3 +8,8 @@ export type Nullable<T> = { [K in keyof T]: T[K] | null }
 export type Mutable<Type> = { -readonly [Key in keyof Type]: Type[Key] }
 export type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 export type DeepReadonly<T> = T extends object ? { [P in keyof T]: DeepReadonly<T[P]> } : T
+declare global {
+  interface Window {
+    expo: any
+  }
+}


### PR DESCRIPTION
Turns out expo has `window` but doesn't have `window.addEventListener`.
So when I import `@quiltt/core` in the react native sdk and use it in an expo app, it just blows up.
```
 console.log('window.expo', !!window.expo)
 LOG  window.expo true
```
I have a hard time to just use `@quiltt/core` directly in the expo example app, so hoping to add one more check, bump the version so I can use the next `@quiltt/core` directly in the expo example app.

In `node`
```
❯ node
Welcome to Node.js v18.15.0.
Type ".help" for more information.
> typeof window !== 'undefined' && !window?.expo
false
```

In browser
```
typeof window !== 'undefined' && !window?.expo
true
```

In Expo
```
console.log('in expo', typeof window !== 'undefined' && !window?.expo)

 LOG  in expo false
```