### PR TITLE
Drop react-native-url-polyfill

### DIFF
--- a/.changeset/eleven-poets-yawn.md
+++ b/.changeset/eleven-poets-yawn.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+Drop react-native-url-polyfill

--- a/ECMAScript/react-native/package.json
+++ b/ECMAScript/react-native/package.json
@@ -28,10 +28,10 @@
     "react-native": "^0.72.5"
   },
   "dependencies": {
-    "react-native-webview": "13.6.2",
     "@quiltt/core": "workspace:*",
     "@quiltt/react": "workspace:*",
-    "react-native-url-polyfill": "2.0.0"
+    "core-js": "3.33.2",
+    "react-native-webview": "13.6.2"
   },
   "devDependencies": {
     "@apollo/client": "3.7.16",
@@ -50,8 +50,7 @@
     "prettier": "2.8.8",
     "react": "18.2.0",
     "tsup": "6.7.0",
-    "typescript": "5.1.3",
-    "core-js": "3.33.2"
+    "typescript": "5.1.3"
   },
   "license": "MIT",
   "publishConfig": {

--- a/ECMAScript/react-native/src/components/QuilttConnector.tsx
+++ b/ECMAScript/react-native/src/components/QuilttConnector.tsx
@@ -8,7 +8,6 @@ import { Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { AndroidSafeAreaView } from './AndroidSafeAreaView'
 import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
-import { URL } from 'react-native-url-polyfill'
 import { useQuilttSession } from '@quiltt/react'
 
 type QuilttConnectorProps = {

--- a/ECMAScript/react-native/src/index.ts
+++ b/ECMAScript/react-native/src/index.ts
@@ -1,6 +1,9 @@
 // Hermes doesn't have atob
 // https://github.com/facebook/hermes/issues/1178
 import 'core-js/stable/atob'
+// React Native's URL implementation is incomplete
+// https://github.com/facebook/react-native/issues/16434
+import 'core-js/stable/url'
 import QuilttConnector from './components/QuilttConnector'
 
 export { QuilttConnector }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,12 +142,12 @@ importers:
       '@quiltt/react':
         specifier: workspace:*
         version: link:../react
+      core-js:
+        specifier: 3.33.2
+        version: 3.33.2
       react-native:
         specifier: ^0.72.5
         version: 0.72.5(@babel/core@7.23.2)(@babel/preset-env@7.23.2)(react@18.2.0)
-      react-native-url-polyfill:
-        specifier: 2.0.0
-        version: 2.0.0(react-native@0.72.5)
       react-native-webview:
         specifier: 13.6.2
         version: 13.6.2(react-native@0.72.5)(react@18.2.0)
@@ -173,9 +173,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 5.60.1
         version: 5.60.1(eslint@8.43.0)(typescript@5.1.3)
-      core-js:
-        specifier: 3.33.2
-        version: 3.33.2
       eslint:
         specifier: 8.43.0
         version: 8.43.0
@@ -3844,7 +3841,7 @@ packages:
   /core-js@3.33.2:
     resolution: {integrity: sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==}
     requiresBuild: true
-    dev: true
+    dev: false
 
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -7284,6 +7281,7 @@ packages:
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
+    dev: true
 
   /qs@6.10.4:
     resolution: {integrity: sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==}
@@ -7336,15 +7334,6 @@ packages:
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
-
-  /react-native-url-polyfill@2.0.0(react-native@0.72.5):
-    resolution: {integrity: sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==}
-    peerDependencies:
-      react-native: '*'
-    dependencies:
-      react-native: 0.72.5(@babel/core@7.23.2)(@babel/preset-env@7.23.2)(react@18.2.0)
-      whatwg-url-without-unicode: 8.0.0-3
-    dev: false
 
   /react-native-webview@13.6.2(react-native@0.72.5)(react@18.2.0):
     resolution: {integrity: sha512-QzhQ5JCU+Nf2W285DtvCZOVQy/MkJXMwNDYPZvOWQbAOgxJMSSO+BtqXTMA1UPugDsko6PxJ0TxSlUwIwJijDg==}
@@ -8654,22 +8643,8 @@ packages:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
 
-  /webidl-conversions@5.0.0:
-    resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
-    engines: {node: '>=8'}
-    dev: false
-
   /whatwg-fetch@3.6.19:
     resolution: {integrity: sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==}
-
-  /whatwg-url-without-unicode@8.0.0-3:
-    resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
-    engines: {node: '>=10'}
-    dependencies:
-      buffer: 5.7.1
-      punycode: 2.3.0
-      webidl-conversions: 5.0.0
-    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}


### PR DESCRIPTION
If I am using `core-js` to polyfill, maybe I don't need `react-native-url-polyfill`.
Plus I think I need core-js in `dependencies` over `devDependencies`.