### PR TITLE
Fix rn package entrypoint

### DIFF
--- a/.changeset/giant-roses-bow.md
+++ b/.changeset/giant-roses-bow.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+Fix React Native package entry point

--- a/ECMAScript/react-native/package.json
+++ b/ECMAScript/react-native/package.json
@@ -2,8 +2,8 @@
   "name": "@quiltt/react-native",
   "version": "3.2.1",
   "description": "React Native components for Quiltt Connector",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",


### PR DESCRIPTION

The package wasn't working, I got this error
```
Unable to resolve '@quiltt/react-native' from 'screens/ConnectorScreen.tsx
```

From GH copilot:
```
GitHub Copilot
In your package.json, you should set:

main to point to the CommonJS entry point, which is typically a .js file.
module to point to the ES Modules entry point, which is typically a .mjs file.
types to point to the TypeScript definitions file, which is a .d.ts file.

main points to dist/index.js, which is the entry point for CommonJS modules. This is used by Node.js and tools that don't support ES Modules.
module points to dist/index.mjs, which is the entry point for ES Modules. This is used by modern bundlers like webpack and Rollup.
types points to dist/index.d.ts, which is the TypeScript definitions file. This is used by TypeScript for type checking and by editors for type inference and autocompletion.
```

Here's my `dist`
```
❯ pushd dist
~/repos/quiltt_workspace/quiltt-public/ECMAScript/react-native/dist ~/repos/quiltt_workspace/quiltt-public/ECMAScript/react-native
❯ ls
index.d.ts	index.js	index.js.map	index.mjs	index.mjs.map
```

Here's my build log
```
@quiltt/react-native:build: CJS Build start
@quiltt/react-native:build: ESM Build start
@quiltt/react-native:build: ESM dist/index.mjs     2.42 KB
@quiltt/react-native:build: ESM dist/index.mjs.map 7.50 KB
@quiltt/react-native:build: ESM ⚡️ Build success in 9ms
@quiltt/react-native:build: CJS dist/index.js     3.01 KB
@quiltt/react-native:build: CJS dist/index.js.map 7.49 KB
@quiltt/react-native:build: CJS ⚡️ Build success in 9ms
@quiltt/react-native:build: DTS Build start
@quiltt/react-native:build: DTS ⚡️ Build success in 922ms
@quiltt/react-native:build: DTS dist/index.d.ts 511.00 B
```