### PR TITLE
Support Plaid oauth in react native sdk

### DIFF
--- a/.changeset/bright-roses-relax.md
+++ b/.changeset/bright-roses-relax.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+React Native sdk to support Plaid Oauth url

--- a/ECMAScript/react-native/src/components/QuilttConnector.tsx
+++ b/ECMAScript/react-native/src/components/QuilttConnector.tsx
@@ -54,11 +54,15 @@ export const QuilttConnector = ({
 
   const eventHandler = (request: ShouldStartLoadRequest) => {
     const url = new URL(request.url)
+    if (url.host.includes('quiltt')) return true
     if (url.protocol === 'quilttconnector:') {
       handleQuilttEvent(url)
       return false
     }
-    return true
+    // Plaid set oauth url by doing window.location.href = url
+    // This is the only way I know to handle this.
+    handleOAuthUrl(url.href)
+    return false
   }
 
   const clearLocalStorage = () => {
@@ -97,13 +101,15 @@ export const QuilttConnector = ({
         onExitSuccess?.(metadata)
         break
       case 'OauthRequested':
-        Linking.openURL(url.searchParams.get('oauthUrl') as string)
+        handleOAuthUrl(url.searchParams.get('oauthUrl') as string)
         break
       default:
         console.log('unhandled event', url)
         break
     }
   }
+
+  const handleOAuthUrl = (oauthUrl: string) => Linking.openURL(oauthUrl)
 
   return (
     <AndroidSafeAreaView>


### PR DESCRIPTION
Closes: https://github.com/quiltt/quiltt-public/issues/154

Plaid Link is setting bank oauth url directly, seems like there isn't a way to even intercept the url and get the oauth url value in web, so I am treating all non quiltt url as oauth url and launch it thru Safari/ Chrome.