### PR TITLE
react native sdk to match the new MessageType

### DIFF
--- a/.changeset/little-jokes-brake.md
+++ b/.changeset/little-jokes-brake.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+Match eventType with MessageType in react native sdk

--- a/ECMAScript/react-native/src/components/QuilttConnector.tsx
+++ b/ECMAScript/react-native/src/components/QuilttConnector.tsx
@@ -73,7 +73,7 @@ export const QuilttConnector = ({
 
     const eventType = url.host
     switch (eventType) {
-      case 'Loaded':
+      case 'Load':
         initInjectedJavaScript()
         onEvent?.(ConnectorSDKEventType.Load, metadata)
         onLoad?.(metadata)


### PR DESCRIPTION
It doesn't seems like we need to adjust much for the `profileId` as it should expose into quilttscheme url search params (https://github.com/quiltt/quiltt-public/blob/1f2ee1aa99f39f349ca1c42c627dd83556d03d68/ECMAScript/react-native/src/components/QuilttConnector.tsx#L72). 

But the `MessageType` was changed from `Loaded` to `Load`, so adjusting in this PR, looks right to you? @sirwolfgang 

