### PR TITLE
[Internal] Rename Deployments to Clients in Auth

### DIFF
--- a/.changeset/honest-donkeys-smell.md
+++ b/.changeset/honest-donkeys-smell.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-native": patch
+"@quiltt/react-test-nextjs": patch
+---
+
+[Internal] Rename Deployments to Clients in Auth

--- a/ECMAScript/core/src/JsonWebToken.ts
+++ b/ECMAScript/core/src/JsonWebToken.ts
@@ -20,7 +20,7 @@ export type RegisteredClaims = {
 export type PrivateClaims = {
   oid: string // Organization ID
   eid: string // Environment ID
-  did: string // Deployment ID
+  cid: string // Client ID
   aid: string // Administrator ID
   ver: number // Session Token Version
 }

--- a/ECMAScript/core/src/api/rest/AuthAPI.ts
+++ b/ECMAScript/core/src/api/rest/AuthAPI.ts
@@ -106,7 +106,7 @@ export class AuthAPI {
 
     return {
       session: {
-        deploymentId: this.clientId, // Rename API?
+        clientId: this.clientId,
         ...payload,
       },
     }


### PR DESCRIPTION
Rename Deployments to Clients in internal auth api. Externally facing interface has been clientId for some time.