### PR TITLE
Improve Changelog + Release flow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "@changesets/changelog-git",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": "@changesets/changelog-git",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@quiltt/core", "@quiltt/react", "@quiltt/react-native"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "turbo run clean",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "publish": "pnpm run build && pnpm -r publish packages --no-git-checks --filter=./ECMAScript/**",
+    "publish": "pnpm run build && npx changeset tag && pnpm -r publish packages --no-git-checks --filter=./ECMAScript/**",
     "cypress": "turbo run cypress",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
This PR upgrades the release flow for the Monorepo.

- Create tags to unblock releases per https://github.com/changesets/action/pull/345
- Improve changelog format
  - From this: https://github.com/quiltt/quiltt-public/blob/main/ECMAScript/react/CHANGELOG.md
  - To this: https://github.com/changesets/changesets/blob/main/packages/cli/CHANGELOG.md