### PR TITLE
Fix Chase app not launching on Android

### DIFF
--- a/ECMAScript/react-native/example/metro.config.js
+++ b/ECMAScript/react-native/example/metro.config.js
@@ -24,7 +24,7 @@ module.exports = {
     extraNodeModules: new Proxy(
       {},
       {
-        get: (target, name) =>
+        get: (_target, name) =>
           name in siblings ? siblings[name] : resolve(process.cwd(), 'node_modules', name),
       }
     ),

--- a/ECMAScript/react-native/src/components/QuilttConnector.tsx
+++ b/ECMAScript/react-native/src/components/QuilttConnector.tsx
@@ -136,9 +136,7 @@ export const QuilttConnector = ({
       console.log(`handleOAuthUrl - Skipping non https url - ${oauthUrl.href}`)
       return
     }
-    if (await Linking.canOpenURL(oauthUrl.href)) {
-      Linking.openURL(oauthUrl.href)
-    }
+    Linking.openURL(oauthUrl.href)
   }
 
   return (


### PR DESCRIPTION
Linking.openURL requires additional AndroidManifest.xml config which
we don't want this hassle for our React Native developer customers.

Since there's a scheme https check, we can confidently say the url can be handle either by
mobile Chrome or correct bank app.

Ref: https://reactnative.dev/docs/linking#canopenurl
