### PR TITLE
Add Institutions to the Connect API

### DIFF
--- a/.changeset/honest-dingos-crash.md
+++ b/.changeset/honest-dingos-crash.md
@@ -1,0 +1,6 @@
+---
+"@quiltt/react": minor
+"@quiltt/core": minor
+---
+
+Add Institutions to the Connect API

--- a/ECMAScript/core/src/api/browser.ts
+++ b/ECMAScript/core/src/api/browser.ts
@@ -71,11 +71,12 @@ export type ConnectorSDKCallbackMetadata = {
   connectionId?: string
 }
 
-export type ConnectorSDKConnectOptions = ConnectorSDKCallbacks
+export type ConnectorSDKConnectOptions = ConnectorSDKCallbacks & {
+  institution?: string
+}
+
 export type ConnectorSDKReconnectOptions = ConnectorSDKCallbacks & {
   connectionId: string
 }
 
-export type ConnectorSDKConnectorOptions = ConnectorSDKConnectOptions & {
-  connectionId?: string
-}
+export type ConnectorSDKConnectorOptions = ConnectorSDKConnectOptions & ConnectorSDKReconnectOptions

--- a/ECMAScript/react/src/hooks/useQuilttConnector.ts
+++ b/ECMAScript/react/src/hooks/useQuilttConnector.ts
@@ -36,9 +36,9 @@ export const useQuilttConnector = (
     if (options?.connectionId) {
       setConnector(Quiltt.reconnect(connectorId, { connectionId: options.connectionId }))
     } else {
-      setConnector(Quiltt.connect(connectorId))
+      setConnector(Quiltt.connect(connectorId, { institution: options?.institution }))
     }
-  }, [status, connectorId, options?.connectionId])
+  }, [status, connectorId, options?.connectionId, options?.institution])
 
   // onEvent
   useEffect(() => {


### PR DESCRIPTION
This exposes the `institution` option for the upcoming version of the Connector API. This allows developers to provide prefilled search terms or selected Institutions. 